### PR TITLE
add libs/imago to include directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dep = $(obj:.o=.d)
 
 bin = tavli
 
-inc = -Ilibs
+inc = -Ilibs -Ilibs/imago
 CFLAGS = -pedantic -Wall -g $(inc)
 CXXFLAGS = -pedantic -Wall -g $(inc)
 LDFLAGS = $(libgl) -lm -lpthread -ldl -lpng -ljpeg -lz


### PR DESCRIPTION
libs/imago was not in the include directories, so it would not compile for me. This should fix that.
